### PR TITLE
Fixes for Rubocop 0.52

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -99,3 +99,7 @@ Naming/VariableNumber:
 
 Style/YodaCondition:
   Enabled: true
+
+Layout/SpaceBeforeBlockBraces:
+  EnforcedStyle: space
+  EnforcedStyleForEmptyBraces: space


### PR DESCRIPTION
* Always use spaces for Layout/SpaceBeforeBlockBraces cop