### PR TITLE
Temporarily disable the Style/FormatStringToken cop

### DIFF
--- a/rubocop.yml
+++ b/rubocop.yml
@@ -103,3 +103,8 @@ Style/YodaCondition:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
+
+# This currently raises a false positive on date format strings. Re-enable this once
+# https://github.com/bbatsov/rubocop/pull/5230 is merged.
+Style/FormatStringToken:
+  Enabled: false


### PR DESCRIPTION
This currently raises a false positive on date format strings. Re-enable this once https://github.com/bbatsov/rubocop/pull/5230 is merged.