### PR TITLE
Bump rubocop to v0.52.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+1.2.2
+-----
+
+* Bump rubocop to 0.52.1
+* Re-enable the `Style/FormatStringToken` cop which was temporarily disabled in v1.2.1
+
 1.2.1
 -----
 

--- a/ruboconfig.gemspec
+++ b/ruboconfig.gemspec
@@ -9,5 +9,5 @@ Gem::Specification.new do |spec|
   spec.license       = "MIT"
 
   spec.files         = "rubocop.yml"
-  spec.add_development_dependency "rubocop", "~> 0.52.0"
+  spec.add_development_dependency "rubocop", "~> 0.52.1"
 end

--- a/ruboconfig.gemspec
+++ b/ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "ruboconfig"
-  spec.version       = "1.2.1"
+  spec.version       = "1.2.2"
   spec.summary       = "shared rubocop config"
   spec.description   = "The GoCardless Engineering shared Rubocop config"
   spec.authors       = %w(GoCardless)

--- a/rubocop.yml
+++ b/rubocop.yml
@@ -103,8 +103,3 @@ Style/YodaCondition:
 Layout/SpaceBeforeBlockBraces:
   EnforcedStyle: space
   EnforcedStyleForEmptyBraces: space
-
-# This currently raises a false positive on date format strings. Re-enable this once
-# https://github.com/bbatsov/rubocop/pull/5230 is merged.
-Style/FormatStringToken:
-  Enabled: false


### PR DESCRIPTION
This bumps the Rubocop dependency to the latest version, and reverts a config change we made to deal with a bug in v0.52.0.