### PR TITLE
Rename the gem to gc_ruboconfig, ahead of release on RubyGems

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 Changelog
 =========
 
+
+2.0.0
+-----
+
+Rename the gem to `gc_ruboconfig` ahead of release on RubyGems (see d73dbee for details)
+
 1.2.2
 -----
 

--- a/README.md
+++ b/README.md
@@ -1,15 +1,17 @@
-Ruboconfig
+gc_ruboconfig
 ==========
 
-GoCardless' shared rubocop configuration.
+GoCardless's shared Rubocop configuration, confirming to our house style.
 
-To use ruboconfig, simply add it to your Gemfile
+To use `gc_ruboconfig`, simply add it to your Gemfile:
+
 ```ruby
-gem 'ruboconfig', git: 'git@github.com:gocardless/ruboconfig'
+gem 'gc_ruboconfig'
 ```
 
-and inherit from it in your `.rubocop.yml`
+Next, just inherit from it in your `.rubocop.yml`:
+
 ```yaml
 inherit_gem:
-  ruboconfig: rubocop.yml
+  gc_ruboconfig: rubocop.yml
 ```

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,6 +1,6 @@
 Gem::Specification.new do |spec|
   spec.name          = "gc_ruboconfig"
-  spec.version       = "1.2.2"
+  spec.version       = "2.0.0"
   spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w(GoCardless)
   spec.homepage      = "https://github.com/gocardless/ruboconfig"

--- a/gc_ruboconfig.gemspec
+++ b/gc_ruboconfig.gemspec
@@ -1,8 +1,7 @@
 Gem::Specification.new do |spec|
-  spec.name          = "ruboconfig"
+  spec.name          = "gc_ruboconfig"
   spec.version       = "1.2.2"
-  spec.summary       = "shared rubocop config"
-  spec.description   = "The GoCardless Engineering shared Rubocop config"
+  spec.summary       = "GoCardless's shared Rubocop configuration, conforming to our house style"
   spec.authors       = %w(GoCardless)
   spec.homepage      = "https://github.com/gocardless/ruboconfig"
   spec.email         = %w(developers@gocardless.com)


### PR DESCRIPTION
Releasing this on RubyGems will make it easier to version and keep up to date in our dependent projects using Dependabot.

Renaming it from plain old "ruboconfig" to "gc_ruboconfig" will help to make it clear that it conforms to GoCardless's house style, rather than any published style guide.

This PR also bumps the gem a major version to v2.0.0, since it will need to be reconfigured in users' `.ruboconfig.yml` files to point to the new gem name.

